### PR TITLE
improvement:优化用户体验,新增了本地构建脚本

### DIFF
--- a/.github/workflows/iPanel-build.yml
+++ b/.github/workflows/iPanel-build.yml
@@ -59,7 +59,16 @@ jobs:
       - name: Build iPanel
         shell: powershell
         run: |
-          dotnet publish iPanel/iPanel.csproj --no-self-contained -p:PublishSingleFile=true -p:IncludeContentInSingleFile=true -p:RuntimeIdentifier=${{ matrix.runtimeIdentifier }} -f net6.0
+          $runtimeIdentifier = "${{ matrix.runtimeIdentifier }}"
+          $defineConstants = ""
+          if ($runtimeIdentifier.StartsWith('win')) {
+            $defineConstants = "-p:DefineConstants=WINDOWS"
+          } elseif ($runtimeIdentifier.StartsWith('linux')) {
+            $defineConstants = "-p:DefineConstants=LINUX"
+          } elseif ($runtimeIdentifier.StartsWith('osx')) {
+            $defineConstants = "-p:DefineConstants=MACOS"
+          }
+          dotnet publish iPanel/iPanel.csproj --no-self-contained -p:PublishSingleFile=true -p:IncludeContentInSingleFile=true -p:RuntimeIdentifier=$runtimeIdentifier $defineConstants -f net6.0
 
       - name: Upload binary files(${{ matrix.runtimeIdentifier }})
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 bin/
 obj/
 .vs/
+release_full_platform/
 
 node_modules
 *.mcdr
 __pycache__/**
 *.pyc
+
+*.csproj.user
+*.pubxml.user
 
 LocalTest/
 TestResults/

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,42 @@
+@echo off
+set the7zpath="C:\Program Files\7-Zip\7z.exe"
+set thepubpath=iPanel\bin\Debug\net6.0\publish\
+set thepubprofilespath=iPanel\Properties\PublishProfiles
+set theprojectname=iPanel
+set thereleasepathname=%~dp0release_full_platform\
+
+rem 获取所有的pubxml文件
+setlocal enabledelayedexpansion
+set directory="%~dp0%thepubprofilespath%"
+for /r %directory% %%F in (*.pubxml) do (
+  echo 正在编译%%~nxF
+  dotnet publish iPanel/iPanel.csproj --no-self-contained /p:PublishProfile=%%~nxF
+)
+
+echo 编译完成，正在打包
+
+:tpack
+if exist %the7zpath% (
+  goto dopack
+) else (
+  echo 7z不存在，无法打包！请安装7-zip的64位版本到C盘！
+  pause
+  exit
+)
+
+:dopack
+echo 正在删除以前release的包
+rd /s /q "%thereleasepathname%"
+
+set /p thever=请输入本次构建的版本号: 
+
+rem 获取所有的文件夹
+set directory=%~dp0%thepubpath%
+for /d %%I in ("%directory%*") do (
+  %the7zpath% a -tzip "%thereleasepathname%%theprojectname%_%thever%_%%~nxI.zip" "%directory%%%~nxI\*"
+  rd /s /q "%directory%%%~nxI"
+)
+
+echo 打包完成
+pause
+start "" "%thereleasepathname%"

--- a/iPanel.sln
+++ b/iPanel.sln
@@ -3,9 +3,26 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "iPanel", "iPanel\iPanel.csproj", "{F47C93EF-F309-4A45-9603-7C8DF6573FE5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "iPanel", "iPanel\iPanel.csproj", "{F47C93EF-F309-4A45-9603-7C8DF6573FE5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "iPanel.Tests", "iPanel.Tests\iPanel.Tests.csproj", "{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "iPanel.Tests", "iPanel.Tests\iPanel.Tests.csproj", "{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}"
 EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F47C93EF-F309-4A45-9603-7C8DF6573FE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F47C93EF-F309-4A45-9603-7C8DF6573FE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F47C93EF-F309-4A45-9603-7C8DF6573FE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F47C93EF-F309-4A45-9603-7C8DF6573FE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA09EE4B-C745-4CD3-B20C-346A5F1C7081}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 EndGlobal

--- a/iPanel/Properties/PublishProfiles/linux-arm.pubxml
+++ b/iPanel/Properties/PublishProfiles/linux-arm.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\linux-arm\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <DefineConstants>LINUX</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/linux-arm64.pubxml
+++ b/iPanel/Properties/PublishProfiles/linux-arm64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\linux-arm64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <DefineConstants>LINUX</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/linux-x64.pubxml
+++ b/iPanel/Properties/PublishProfiles/linux-x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\linux-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <DefineConstants>LINUX</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/osx-arm64.pubxml
+++ b/iPanel/Properties/PublishProfiles/osx-arm64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\osx-arm64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <DefineConstants>MACOS</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/osx-x64.pubxml
+++ b/iPanel/Properties/PublishProfiles/osx-x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\osx-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <DefineConstants>MACOS</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/win-x64.pubxml
+++ b/iPanel/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Properties/PublishProfiles/win-x86.pubxml
+++ b/iPanel/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net6.0\publish\win-x86\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/iPanel/Utils/CommandLineHelper.cs
+++ b/iPanel/Utils/CommandLineHelper.cs
@@ -6,10 +6,20 @@ using System.CommandLine;
 using System.IO;
 using System.Text.Json;
 
+#if WINDOWS
+using System.Runtime.InteropServices;
+#endif
+
 namespace iPanel.Utils;
 
 public static class CommandLineHelper
 {
+
+#if WINDOWS
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern int MessageBox(IntPtr hWnd, string text, string caption, uint type);
+#endif
+
     public static RootCommand Create()
     {
         var rootCommnad = new RootCommand();
@@ -36,11 +46,28 @@ public static class CommandLineHelper
         if (!File.Exists("setting.json"))
         {
             WriteSetting();
+#if WINDOWS
+            MessageBox(IntPtr.Zero, "\"setting.json\"不存在，现已重新创建，请修改后重启", "错误", 0x10 | 0x0);
+#endif
             throw new FileNotFoundException("\"setting.json\"不存在，现已重新创建，请修改后重启");
         }
-        return JsonSerializer.Deserialize<Setting>(
-                File.ReadAllText("setting.json"),
-                JsonSerializerOptionsFactory.CamelCase
-            ) ?? throw new NullReferenceException("文件为空");
+        Setting? settingfilevalue = null;
+        try
+        {
+            settingfilevalue = JsonSerializer.Deserialize<Setting>(File.ReadAllText("setting.json"), JsonSerializerOptionsFactory.CamelCase);
+            if (settingfilevalue == null)
+            {
+                throw new NullReferenceException("文件为空");
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Console.Error.WriteLine("读取设置文件发生异常: " + ex.Message);
+#if WINDOWS
+            MessageBox(IntPtr.Zero, "读取设置文件发生异常:\r\n" + ex.Message, "错误", 0x10 | 0x0);
+#endif
+            throw;
+        }
+        return settingfilevalue;
     }
 }

--- a/iPanel/iPanel.csproj
+++ b/iPanel/iPanel.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <Authors>iPanelDev</Authors>
-        <Version>2.3.0.0-alpha</Version>
+        <Version>2.3.1.0-alpha</Version>
         <Company>https://ipaneldev.github.io/</Company>
         <Description>iPanel网页面板后端</Description>
         <Product>iPanel网页面板后端</Product>


### PR DESCRIPTION
improvement:优化用户体验,新增了本地构建脚本
1.iPanel第一次运行生成的配置文件的``InstancePassword``是空的，再次启动会导致程序检测到``InstancePassword``为空再次崩溃
为Setting添加新私有方法，创建随机的8位大小写字母数字混合密码
2.添加了适用于vs2022的自动release全平台可执行程序的脚本
在``.\iPanel\Properties\PublishProfiles``下添加了发布的xml文件
在安装了``7-zip x64``位到``C:\Program Files\7-Zip``
并且在``.\iPanel\Sources\``下放置了网页压缩包``webconsole.zip``后
运行``.\build.bat``即可在``.\release_full_platform``下生成全平台的、打包好的可执行程序，它的构建速度远快于github action
3.修改了action和pubxml，支持在编译时指定对应平台的宏
自动在编译对应系统的文件时添加WINDOWS、LINUX、MACOS的宏
4.windows下配置读取如果出现异常，用户不会收到任何提示，这会让用户困惑
针对windows条件编译，为这种情况额外添加消息框显示错误信息
5.更新版本号为2.3.1